### PR TITLE
feat: initial webapp setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your_openai_api_key
+MONGODB_URI=your_mongodb_connection

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+# project folders
+client/node_modules
+server/node_modules
+server/uploads

--- a/README.md
+++ b/README.md
@@ -12,9 +12,22 @@ BlackBox QA를 할 때, 사양서와 실제 코드 변경사항의 차이를 분
 2. Repository - GitHub Repo
 3. QA Test Case - QA가 작성한 테스트케이스
 
-## How it works
-1. GitHub Changes
-2. Test Case Changes
+## Architecture
 
-구체적인 사양의 링크는 QA Test Case의 링크로 제공되어도 되며, AI 관점에서는 구체적인 내용은 몰라도 된다. 
+The repository includes a React + TypeScript frontend (`client`) and an Express + MongoDB backend (`server`).
+Test cases are uploaded as CSV files where each line describes a test case identifier followed by step descriptions.
+The backend reads git diffs from a repository, sends them together with the test cases to the ChatGPT API, and returns only impacted test cases.
+
+### Environment
+
+Create a `.env` file based on `.env.example` and supply values for `OPENAI_API_KEY` and `MONGODB_URI`.
+
+### Development
+
+```bash
+# start backend
+npm --prefix server run dev
+# start frontend
+npm --prefix client run dev
+```
 

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>QA Scope Finder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "qa-scope-finder-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@mui/material": "^5.14.5",
+    "@mui/icons-material": "^5.14.5",
+    "axios": "^1.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.2",
+    "vite": "^4.5.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Button, TextField, Autocomplete, List, ListItem, Typography } from '@mui/material';
+import { Project, StepCase } from './types';
+import { getProjects, createProject, analyze } from './api';
+
+const App: React.FC = () => {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selected, setSelected] = useState<Project | null>(null);
+  const [search, setSearch] = useState('');
+  const [cases, setCases] = useState<StepCase[]>([]);
+
+  useEffect(() => {
+    getProjects().then(p => setProjects(p));
+  }, []);
+
+  useEffect(() => {
+    setCases(selected?.cases || []);
+  }, [selected]);
+
+  const filtered = cases.filter(c =>
+    c.caseId.toLowerCase().includes(search.toLowerCase()) ||
+    c.steps.join(' ').toLowerCase().includes(search.toLowerCase())
+  );
+
+  const handleAnalyze = async () => {
+    if (!selected) return;
+    const result = await analyze(selected._id);
+    setCases(result);
+  };
+
+  return (
+    <Box p={2}>
+      <Box display="flex" gap={2} mb={2}>
+        <Autocomplete
+          options={projects}
+          getOptionLabel={p => p.name}
+          sx={{ width: 300 }}
+          value={selected}
+          onChange={(_e, value) => setSelected(value)}
+          renderInput={params => <TextField {...params} label="Project" />}
+        />
+        <Button variant="contained" component="label">
+          New Project
+          <input
+            hidden
+            type="file"
+            accept=".csv"
+            onChange={async e => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              const name = prompt('Project name?') || 'New Project';
+              const repoUrl = prompt('Repo URL?') || '';
+              const project = await createProject(name, repoUrl, file);
+              setProjects(prev => [...prev, project]);
+              setSelected(project);
+            }}
+          />
+        </Button>
+        <TextField
+          label="Search"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <Button variant="outlined" onClick={handleAnalyze} disabled={!selected}>
+          Analyze
+        </Button>
+      </Box>
+
+      <List>
+        {filtered.map(c => (
+          <ListItem key={c.caseId} alignItems="flex-start">
+            <Box>
+              <Typography variant="subtitle1">{c.caseId}</Typography>
+              <ol>
+                {c.steps.map((s, i) => (
+                  <li key={i}>{s}</li>
+                ))}
+              </ol>
+            </Box>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default App;

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import { Project, StepCase } from './types';
+
+const api = axios.create({ baseURL: '/projects' });
+
+export async function getProjects(): Promise<Project[]> {
+  const res = await api.get<Project[]>('/');
+  return res.data;
+}
+
+export async function createProject(name: string, repoUrl: string, file: File): Promise<Project> {
+  const form = new FormData();
+  form.append('name', name);
+  form.append('repoUrl', repoUrl);
+  form.append('file', file);
+  const res = await api.post<Project>('/', form, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+  return res.data;
+}
+
+export async function analyze(id: string): Promise<StepCase[]> {
+  const res = await api.post<StepCase[]>(`/${id}/analyze`);
+  return res.data;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,0 +1,11 @@
+export interface StepCase {
+  caseId: string;
+  steps: string[];
+}
+
+export interface Project {
+  _id: string;
+  name: string;
+  repoUrl: string;
+  cases: StepCase[];
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "qa-scope-finder-server",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev src/index.ts",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "mongoose": "^7.6.1",
+    "dotenv": "^16.0.3",
+    "csv-parse": "^5.3.7",
+    "openai": "^4.0.0",
+    "simple-git": "^3.19.1",
+    "multer": "^1.4.5"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.4.1",
+    "@types/multer": "^1.4.7",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.2"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import cors from 'cors';
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import projectsRouter from './routes/projects';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+mongoose.connect(process.env.MONGODB_URI || '');
+
+app.use('/projects', projectsRouter);
+
+const port = process.env.PORT || 4000;
+app.listen(port, () => {
+  console.log(`Server running on ${port}`);
+});

--- a/server/src/models/Project.ts
+++ b/server/src/models/Project.ts
@@ -1,0 +1,25 @@
+import { Schema, model, Document } from 'mongoose';
+
+export interface StepCase {
+  caseId: string;
+  steps: string[];
+}
+
+export interface ProjectDoc extends Document {
+  name: string;
+  repoUrl: string;
+  cases: StepCase[];
+}
+
+const StepSchema = new Schema<StepCase>({
+  caseId: { type: String, required: true },
+  steps: { type: [String], required: true }
+});
+
+const ProjectSchema = new Schema<ProjectDoc>({
+  name: { type: String, required: true },
+  repoUrl: { type: String, required: true },
+  cases: { type: [StepSchema], default: [] }
+});
+
+export default model<ProjectDoc>('Project', ProjectSchema);

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import multer from 'multer';
+import Project from '../models/Project';
+import { parseCsv } from '../utils/csv';
+import { analyzeRepo } from '../services/analyze';
+
+const upload = multer({ dest: 'uploads/' });
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const projects = await Project.find();
+  res.json(projects);
+});
+
+router.post('/', upload.single('file'), async (req, res) => {
+  const { name, repoUrl } = req.body;
+  if (!req.file) {
+    return res.status(400).send('CSV file required');
+  }
+  const cases = await parseCsv(req.file.path);
+  const project = await Project.create({ name, repoUrl, cases });
+  res.json(project);
+});
+
+router.post('/:id/analyze', async (req, res) => {
+  const project = await Project.findById(req.params.id);
+  if (!project) return res.sendStatus(404);
+  const filtered = await analyzeRepo(project.repoUrl, project.cases);
+  res.json(filtered);
+});
+
+export default router;

--- a/server/src/services/analyze.ts
+++ b/server/src/services/analyze.ts
@@ -1,0 +1,31 @@
+import { OpenAI } from 'openai';
+import simpleGit from 'simple-git';
+import fs from 'fs';
+import path from 'path';
+import { StepCase } from '../models/Project';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+function buildPrompt(diff: string, cases: StepCase[]): string {
+  const caseText = cases
+    .map(c => `${c.caseId}: ${c.steps.join(' -> ')}`)
+    .join('\n');
+  return `Given the following git diff:\n${diff}\n\nAnd test cases:\n${caseText}\n\nReturn a JSON array of test case IDs that are affected.`;
+}
+
+export async function analyzeRepo(repoUrl: string, cases: StepCase[]): Promise<StepCase[]> {
+  const tmp = fs.mkdtempSync(path.join(process.cwd(), 'repo-'));
+  const git = simpleGit();
+  await git.clone(repoUrl, tmp);
+  const diff = await simpleGit(tmp).diff();
+  const prompt = buildPrompt(diff, cases);
+
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: prompt }]
+  });
+
+  const content = completion.choices[0].message?.content || '[]';
+  const ids: string[] = JSON.parse(content);
+  return cases.filter(c => ids.includes(c.caseId));
+}

--- a/server/src/utils/csv.ts
+++ b/server/src/utils/csv.ts
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import { parse } from 'csv-parse';
+import { StepCase } from '../models/Project';
+
+export async function parseCsv(filePath: string): Promise<StepCase[]> {
+  const cases: StepCase[] = [];
+  return new Promise((resolve, reject) => {
+    fs.createReadStream(filePath)
+      .pipe(parse({ delimiter: ',', trim: true }))
+      .on('data', (row: string[]) => {
+        if (!row.length) return;
+        const [caseId, ...steps] = row;
+        cases.push({ caseId, steps });
+      })
+      .on('end', () => resolve(cases))
+      .on('error', reject);
+  });
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "ES2019",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold Express/MongoDB backend with project CRUD and OpenAI-based diff analysis
- add React + MUI SPA for project selection, CSV upload, search, and analysis
- document environment variables and project layout

## Testing
- `npm --prefix server test`
- `npm --prefix client test`
- `npm --prefix server run build` *(fails: Cannot find module 'express'...)*
- `npm --prefix client run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68b6edfb3fd4832e9bebd4d320ef7498